### PR TITLE
fix build error in FreeBSD

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -63,6 +63,10 @@
                     "GCC_DYNAMIC_NO_PIC": "NO",
                     "OTHER_CFLAGS": ["-pedantic"]
                 }
+            }],
+            ["OS=='freebsd'", {
+                "cflags_cc": ["-fPIC", "-pedantic", "-fexceptions"],
+                "cflags_cc!": ["-fno-exceptions"]
             }]
         ]
     }]

--- a/binding.gyp
+++ b/binding.gyp
@@ -43,7 +43,7 @@
             "./deps/snap7/src/lib/snap7_libmain.cpp"
         ],
         "conditions": [
-            ["OS=='linux'", {
+            ["OS=='linux' or OS=='freebsd'", {
                 "cflags_cc": ["-fPIC", "-pedantic", "-fexceptions"],
                 "cflags_cc!": ["-fno-exceptions"]
             }],
@@ -63,10 +63,6 @@
                     "GCC_DYNAMIC_NO_PIC": "NO",
                     "OTHER_CFLAGS": ["-pedantic"]
                 }
-            }],
-            ["OS=='freebsd'", {
-                "cflags_cc": ["-fPIC", "-pedantic", "-fexceptions"],
-                "cflags_cc!": ["-fno-exceptions"]
             }]
         ]
     }]


### PR DESCRIPTION
FreeBSD's gyp OS value is different from Linux, so I add this OS type in binding.gyp.
FreeBSD 9+ use Clang for compile by default. 
I tested in FreeBSD 10.3 with Clang 3.4.1, it works fine. No need to install gcc/g++/python.