### PR TITLE
Update dependencies to ensure compatibility with Node 22

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node: [16, 18, 20]
+        node: [16, 18, 20, 22]
         arch: [x86, x64]
         exclude:
           - { os: ubuntu-latest, arch: x86 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Test and Release](https://github.com/mathiask88/node-snap7/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/mathiask88/node-snap7/actions/workflows/test-and-release.yml)
 [![npm](https://img.shields.io/npm/dm/node-snap7.svg?label=dl)](https://www.npmjs.com/package/node-snap7)
 
-**Current node-snap7 version:** 1.0.7\
+**Current node-snap7 version:** 1.0.8\
 **Current snap7 version:** 1.4.2
 
 **In my spare time I am working on a [node-addon-api](https://github.com/nodejs/node-addon-api) rewrite and want to switch from [prebuild-install](https://github.com/prebuild/prebuild-install) to [prebuildify](https://github.com/prebuild/prebuildify).\

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-snap7",
   "main": "./lib/node-snap7.js",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Native node.js addon/wrapper for snap7",
   "homepage": "https://github.com/mathiask88/node-snap7",
   "repository": {
@@ -18,17 +18,17 @@
     "name": "Mathias Küsel"
   },
   "engines": {
-    "node": ">=16"
+    "node": "^16 || ^18 || ^20 || ^22"
   },
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~2.18.0",
-    "bindings": "~1.5.0",
-    "prebuild-install": "^7.1.1"
+    "nan": "^2.22.0",
+    "bindings": "^1.5.0",
+    "prebuild-install": "^7.1.2"
   },
   "devDependencies": {
-    "prebuild": "^12.1.0",
+    "prebuild": "^13.0.1",
     "prebuild-ci": "^4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
- explicitly state compability only to node version that where tested
- extend work flow to node 22
- update dependencies to ensure compatibility with Node 22
- Step node-snap7 version number to 1.0.8

fixes #98
