### PR TITLE
Fix GetParam to return actual value (and correct u16 handling)

### DIFF
--- a/src/node_snap7_client.cpp
+++ b/src/node_snap7_client.cpp
@@ -829,20 +829,42 @@ NAN_METHOD(S7Client::Disconnect) {
 }
 
 NAN_METHOD(S7Client::GetParam) {
+  int paramNumber, ret;
+  int pData = 0;
+  uint16_t pU16Data = 0;
+
   S7Client *s7client = ObjectWrap::Unwrap<S7Client>(info.Holder());
 
   if (!info[0]->IsInt32()) {
     return Nan::ThrowTypeError("Wrong arguments");
   }
 
-  int pData;
-  int returnValue = s7client->snap7Client->GetParam(Nan::To<int32_t>(info[0]).FromJust()
-    , &pData);
+  paramNumber = Nan::To<int32_t>(info[0]).FromJust();
 
-  if (returnValue == 0) {
-    info.GetReturnValue().Set(Nan::New<v8::Integer>(pData));
+  switch (paramNumber) {
+    case p_u16_RemotePort:
+    case p_u16_SrcRef:
+    case p_u16_DstRef:
+    case p_u16_SrcTSap:
+      ret = s7client->snap7Client->GetParam(paramNumber, &pU16Data);
+      break;
+    default:
+      ret = s7client->snap7Client->GetParam(paramNumber, &pData);
+      break;
+  }
+
+  if (ret != 0) {
+    info.GetReturnValue().Set(Nan::New<v8::Integer>(ret));
+    return;
+  }
+
+  if (paramNumber == p_u16_RemotePort ||
+    paramNumber == p_u16_SrcRef ||
+    paramNumber == p_u16_DstRef ||
+    paramNumber == p_u16_SrcTSap) {
+    info.GetReturnValue().Set(Nan::New<v8::Integer>(pU16Data));
   } else {
-    info.GetReturnValue().Set(Nan::New<v8::Integer>(returnValue));
+    info.GetReturnValue().Set(Nan::New<v8::Integer>(pData));
   }
 }
 

--- a/src/node_snap7_server.cpp
+++ b/src/node_snap7_server.cpp
@@ -976,18 +976,36 @@ NAN_METHOD(S7Server::SetResourceless) {
 }
 
 NAN_METHOD(S7Server::GetParam) {
+  int paramNumber, ret;
+  int pData = 0;
+  uint16_t pU16Data = 0;
+
   S7Server *s7server = ObjectWrap::Unwrap<S7Server>(info.Holder());
 
   if (!info[0]->IsInt32()) {
     return Nan::ThrowTypeError("Wrong arguments");
   }
 
-  int pData;
-  int ret = s7server->snap7Server->GetParam(Nan::To<int32_t>(info[0]).FromJust()
-    , &pData);
+  paramNumber = Nan::To<int32_t>(info[0]).FromJust();
+
+  if (paramNumber == p_u16_LocalPort) {
+    ret = s7server->snap7Server->GetParam(paramNumber, &pU16Data);
+  } else {
+    ret = s7server->snap7Server->GetParam(paramNumber, &pData);
+  }
+
   s7server->lastError = ret;
 
-  info.GetReturnValue().Set(Nan::New<v8::Boolean>(ret == 0));
+  if (ret != 0) {
+    info.GetReturnValue().Set(Nan::False());
+    return;
+  }
+
+  if (paramNumber == p_u16_LocalPort) {
+    info.GetReturnValue().Set(Nan::New<v8::Integer>(pU16Data));
+  } else {
+    info.GetReturnValue().Set(Nan::New<v8::Integer>(pData)); 
+  }
 }
 
 NAN_METHOD(S7Server::SetParam) {


### PR DESCRIPTION
### What changed
- Fix `GetParam` to return the actual parameter value instead of a boolean result.
- Correct handling of `uint16_t` parameters (port / ref related).

### Why
`GetParam` was incorrectly treated as a success flag, so the real value was never returned.
While fixing this, incorrect `uint16_t` usage was also discovered and corrected.

### Compatibility
No breaking change.  
On success: returns a number.  
On failure: returns the Snap7 error code (same as before).

Fixes #87